### PR TITLE
Image customization standalone scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,66 @@ Interface with the Roboflow API and Python package for running inference (receiv
 # GitHub Repo Structure:
 * The `Images` directory contains necessary code for running inference (model predictions) on individual images, and folders (directories) of images
 * `predictionUtils.py` is written in an Object-Oriented Programming framework, and contains necessary code for interacting with `Images.py` for saving [customized] images from inference results.
+* cropBoxes.py: crop the area within predicted bounding boxes and save the results
+```
+# default root save location: './inference_images'
+# default confidence and overelap for predictions: confidence = 40, overlap = 30
+cd images
+python3 cropBoxes.py
+```
+  * To be used after updating the `roboflow_config.json` file in the main directory with your Model Info (Workpsace ID, Model/Project ID, Private API Key and Model Version Number)
+  * Available in `roboflow-computer-vision-utilities/images`
+  * `./inference_images` can be left "as-is" if desired, as the script creates this directory to organize inference results
+* fillBoxes.py: fill in (obscure) the area within predicted bounding boxes and save the results
+```
+# default root save location: './inference_images'
+# default confidence and overelap for predictions: confidence = 40, overlap = 30
+cd images
+python3 fillBoxes.py
+```
+  * To be used after updating the `roboflow_config.json` file in the main directory with your Model Info (Workpsace ID, Model/Project ID, Private API Key and Model Version Number)
+  * Available in `roboflow-computer-vision-utilities/images`
+  * `./inference_images` can be left "as-is" if desired, as the script creates this directory to organize inference results
+* blurBoxes.py: blur the area within predicted bounding boxes and save the results - good for those wanting to make face detection models with privacy filters, for example
+```
+# default root save location: './inference_images'
+# default confidence and overelap for predictions: confidence = 40, overlap = 30
+cd images
+python3 blurBoxes.py
+```
+  * To be used after updating the `roboflow_config.json` file in the main directory with your Model Info (Workpsace ID, Model/Project ID, Private API Key and Model Version Number)
+  * Available in `roboflow-computer-vision-utilities/images`
+  * `./inference_images` can be left "as-is" if desired, as the script creates this directory to organize inference results
 * `twoPass.py`: Code for running inference (model predictions) in "two stages" on images.
+```
+# default root save location: './inference_images'
+# also moves all images in /roboflow-computer-vision-utilities to /roboflow-computer-vision-utilities/inference_images before inferrence
+cd images
+python3 twoPass.py
+```
   * Ex. Stage 1: object detection (find faces) --> crop the detected areas and send to --> Stage 2: classification (is this a real image or illustrated?)
+  * To be used after updating the `roboflow_config.json` file in the main directory with your Model Info (Workpsace ID, Model/Project ID, Private API Key and Model Version Number)
   * Available in `roboflow-computer-vision-utilities/images`
 * `webcam_od.py`: Code for running inference (model predictions) with Object Detection models on webcam feeds
+```
+cd webcam
+python3 webcam_od.py
+```
+  * To be used after updating the `roboflow_config.json` file in the main directory with your Model Info (Workpsace ID, Model/Project ID, Private API Key and Model Version Number)
   * Available in `roboflow-computer-vision-utilities/webcam`
 * `webcam_classification.py`: Code for running inference (model predictions) with Classification models on webcam feeds
+```
+cd webcam
+python3 webcam_classification.py
+```
+  * To be used after updating the `roboflow_config.json` file in the main directory with your Model Info (Workpsace ID, Model/Project ID, Private API Key and Model Version Number)
   * Available in `roboflow-computer-vision-utilities/webcam`
 
 [In Progress]:
 * `Video.py`: Code for running inference (model predictions) on local video files
+* `sendText.py`: Code for running inference (model predictions) and sending a text message when a specified detection type is made
+* `sendNotification.py`: Code for running inference (model predictions) and sending a notification to a smartphone when a specified detection type is made
+* `playSound.py`: Code for running inference (model predictions) and playing a sound when a specified detection type is made
 
 ## Installation (Dependencies):
 

--- a/images/blurBoxes.py
+++ b/images/blurBoxes.py
@@ -1,0 +1,140 @@
+import os, glob, shutil
+from roboflow import Roboflow
+import json
+import cv2
+
+
+def blurBoxes(model, img_path, printJson = True, save_img = True, confidence = 40, overlap = 30):
+    """
+    This function blurs the bounding boxes on images passed for prediction to your Roboflow model endpoint and also saves the "unblurred" prediction image\n
+    :param model: Roboflow model object for the first inference pass\n
+    :param img_path: string, path to the image for inference\n
+    :param printJson: bool, default: True - prints the JSON values of the predictions from the second inference pass\n
+    :param save_img: bool, default: True - saves the prediction image [crop] from the second inference pass\n
+    :param confidence: int, default: 40 - minimum confidence level (%) to return predictions\n
+    :param overlap: int, default: 30 - maximum prediction overlap (% bounding boxes can overlap prior to being considered the same box/detection)
+    """
+    ##s for a directory (folder) of images
+    if os.path.isdir(img_path):
+        raw_data_location = img_path
+        for raw_data_ext in ['.jpg', '.jpeg', 'png']:
+            globbed_files = glob.glob(raw_data_location + '/*' + raw_data_ext)
+            for img_file in globbed_files:
+                img = cv2.imread(img_file)
+                ## perform inference on the selected image
+                predictions = model.predict(img_file, confidence=confidence,
+                    overlap=overlap)
+                #predictions_json = predictions.json()
+                original_file = os.path.basename(img_file).split('/')[-1]
+                predictions.save(os.curdir + f"/inference_images/inferred/{original_file}")
+                ## drawing bounding boxes with the Pillow library
+                ## https://docs.roboflow.com/inference/hosted-api#response-object-format
+                for bounding_box in predictions:
+                    ## defining bounding box area to blur
+                    blur_x = int(bounding_box['x'] - bounding_box['width'] / 2)
+                    blur_y = int(bounding_box['y'] - bounding_box['height'] / 2)
+                    blur_width = int(bounding_box['width'])
+                    blur_height = int(bounding_box['height'])
+                    ## region of interest (ROI), or area to blur
+                    roi = img[blur_y:blur_y+blur_height, blur_x:blur_x+blur_width]
+
+                    ## ADD BLURRED BBOXES
+                    ## set blur to (31,31) or (51,51) based on amount of blur desired
+                    blur_image = cv2.GaussianBlur(roi,(51,51),0)
+                    img[blur_y:blur_y+blur_height, blur_x:blur_x+blur_width] = blur_image
+
+                    if save_img:
+                        if os.path.exists(os.curdir + f"/inference_images/blurBoxes"
+                            ) is False:
+                            os.mkdir(os.curdir + f"/inference_images/blurBoxes")
+                        
+                        filename = original_file
+                        save_loc = f'./inference_images/blurBoxes/' + filename
+                        cv2.imwrite(save_loc, img)
+
+                        print(f'Success! Saved to {save_loc}')
+
+                    if printJson:
+                        print(f'\n{bounding_box}')
+                        
+    ## runs if there is only 1 image file in the ./inference_images directory
+    elif os.path.isfile(img_path):
+        img = cv2.imread(img_path)
+        ## perform inference on the selected image
+        predictions = model.predict(img_path, confidence=confidence,
+            overlap=overlap)
+        #predictions_json = predictions.json()
+        original_file = os.path.basename(img_path).split('/')[-1]
+        predictions.save(os.curdir + f"/inference_images/inferred/{original_file}")
+        ## drawing bounding boxes with the Pillow library
+        ## https://docs.roboflow.com/inference/hosted-api#response-object-format
+        for bounding_box in predictions:
+            ## defining bounding box area to blur
+            blur_x = int(bounding_box['x'] - bounding_box['width'] / 2)
+            blur_y = int(bounding_box['y'] - bounding_box['height'] / 2)
+            blur_width = int(bounding_box['width'])
+            blur_height = int(bounding_box['height'])
+            ## region of interest (ROI), or area to blur
+            roi = img[blur_y:blur_y+blur_height, blur_x:blur_x+blur_width]
+
+            ## ADD BLURRED BBOXES
+            ## set blur to (31,31) or (51,51) based on amount of blur desired
+            blur_image = cv2.GaussianBlur(roi,(51,51),0)
+            img[blur_y:blur_y+blur_height, blur_x:blur_x+blur_width] = blur_image
+
+            if save_img:
+                if os.path.exists(os.curdir + f"/inference_images/blurBoxes"
+                    ) is False:
+                    os.mkdir(os.curdir + f"/inference_images/blurBoxes")
+                
+                filename = original_file
+                save_loc = f'./inference_images/blurBoxes/' + filename
+                cv2.imwrite(save_loc, img)
+
+                print(f'Success! Saved to {save_loc}')
+
+            if printJson:
+                print(f'\n{bounding_box}')
+                
+    else:
+        return print('Please input a valid path to an image or directory (folder)')
+
+
+## load config file for the models
+with open(os.pardir + '/roboflow_config.json') as f:
+    config = json.load(f)
+
+    ROBOFLOW_API_KEY = config["ROBOFLOW_API_KEY"]
+    ROBOFLOW_WORKSPACE_ID = config["ROBOFLOW_WORKSPACE_ID"]
+    ROBOFLOW_MODEL_ID = config["ROBOFLOW_MODEL_ID"]
+    ROBOFLOW_VERSION_NUMBER = config["ROBOFLOW_VERSION_NUMBER"]
+    ROBOFLOW_SIZE = config["ROBOFLOW_SIZE"]
+
+    f.close()
+
+## obtaining your API key: https://docs.roboflow.com/rest-api#obtaining-your-api-key
+## create Roboflow object: https://docs.roboflow.com/python
+rf = Roboflow(api_key=ROBOFLOW_API_KEY)
+workspace = rf.workspace(ROBOFLOW_WORKSPACE_ID)
+project = workspace.project(ROBOFLOW_MODEL_ID)
+version = project.version(ROBOFLOW_VERSION_NUMBER)
+model = version.model
+
+## creating a directory to add images we wish to infer
+if os.path.exists(os.curdir + '/inference_images') is False:
+    os.mkdir(os.curdir + '/inference_images')
+
+## creating directory to place Roboflow prediction images
+if os.path.exists(os.curdir + '/inference_images/inferred') is False:
+    os.mkdir(os.curdir + '/inference_images/inferred')
+
+## creating directory to place prediction images with blurred bounding boxes
+if os.path.exists(os.curdir + '/inference_images/blurBoxes') is False:
+    os.mkdir(os.curdir + '/inference_images/blurBoxes')
+
+for raw_data_ext in ['.jpg', '.jpeg', 'png']:
+    globbed_files = glob.glob(os.curdir + '/*' + raw_data_ext)
+    for img_file in globbed_files:
+        shutil.move(img_file, os.curdir + '/inference_images')
+
+blurBoxes(model, './inference_images', confidence = 40, overlap = 30)

--- a/images/cropBoxes.py
+++ b/images/cropBoxes.py
@@ -1,0 +1,147 @@
+import os, glob, shutil
+from roboflow import Roboflow
+import json
+import cv2
+
+
+def cropBoxes(model, img_path, printJson = True, save_img = True, confidence = 40, overlap = 30):
+    """
+    This functio fills the bounding boxes on images passed for prediction to your Roboflow model endpoint and also saves the "unfilled" prediction image\n
+    :param model1: Roboflow model object for the first inference pass\n
+    :param img_path: string, path to the image for inference\n
+    :param printJson: bool, default: True - prints the JSON values of the predictions from the second inference pass\n
+    :param save_img: bool, default: True - saves the prediction image [crop] from the second inference pass\n
+    :param confidence: int, default: 40 - minimum confidence level (%) to return predictions\n
+    :param overlap: int, default: 30 - maximum prediction overlap (% bounding boxes can overlap prior to being considered the same box/detection)
+    """
+    ## for a directory (folder) of images
+    if os.path.isdir(img_path):
+        raw_data_location = img_path
+        for raw_data_ext in ['.jpg', '.jpeg', 'png']:
+            globbed_files = glob.glob(raw_data_location + '/*' + raw_data_ext)
+            for img_file in globbed_files:
+                crop_number = 0
+                img = cv2.imread(img_file)
+                ## perform inference on the selected image
+                predictions = model.predict(img_file, confidence=confidence,
+                    overlap=overlap)             
+                predictions_json = predictions.json()
+                if predictions_json['predictions'] == []:
+                    print(f"No predictions for {img_path} at confidence: {confidence} and overlap {overlap}")
+                else:
+                    original_file = os.path.basename(img_path).split('/')[-1]
+                    predictions.save(os.curdir + f"/inference_images/inferred/{original_file}")
+                    ## drawing bounding boxes with the Pillow library
+                    ## https://docs.roboflow.com/inference/hosted-api#response-object-format
+                    for bounding_box in predictions:
+                        # defining crop area [height_of_cropArea:width_of_cropArea]
+                        # croppedArea = img[start_row:end_row, start_col:end_col]
+                        x0 = bounding_box['x'] - bounding_box['width'] / 2#start_column
+                        x1 = bounding_box['x'] + bounding_box['width'] / 2#end_column
+                        y0 = bounding_box['y'] - bounding_box['height'] / 2#start row
+                        y1 = bounding_box['y'] + bounding_box['height'] / 2#end_row
+                        class_name = bounding_box['class']
+                        croppedArea = img[int(y0):int(y1), int(x0):int(x1)]
+                        #confidence_score = bounding_box['confidence']#confidence score of prediction
+
+                        if save_img:
+                            if os.path.exists(os.curdir + f"/inference_images/cropBoxes/DetectedAs_{class_name}"
+                                ) is False:
+                                os.mkdir(os.curdir + f"/inference_images/cropBoxes/DetectedAs_{class_name}")
+                            
+                            filename = f"Crop{crop_number}_{original_file}"
+                            save_loc = f'./inference_images/cropBoxes/DetectedAs_{class_name}/' + filename
+                            print(filename, save_loc)
+                            print(img_file)
+                            cv2.imwrite(save_loc, croppedArea)
+
+                            print(f'Success! Saved to {save_loc}')
+                            crop_number+=1
+
+                        if printJson:
+                            print(f'\n{bounding_box}')
+                        
+    ## runs if there is only 1 image file in the ./inference_images directory
+    elif os.path.isfile(img_path):
+        crop_number = 0
+        img = cv2.imread(img_path)
+        # perform inference on the selected image
+        predictions = model.predict(img_path, confidence=confidence,
+            overlap=overlap)
+        predictions_json = predictions.json()
+        if predictions_json['predictions'] == []:
+            print(f"No predictions for {img_path} at confidence: {confidence} and overlap {overlap}")
+        else:
+            original_file = os.path.basename(img_path).split('/')[-1]
+            predictions.save(os.curdir + f"/inference_images/inferred/{original_file}")
+            # drawing bounding boxes with the Pillow library
+            # https://docs.roboflow.com/inference/hosted-api#response-object-format
+            for bounding_box in predictions:
+                # defining crop area [height_of_cropArea:width_of_cropArea]
+                # croppedArea = img[start_row:end_row, start_col:end_col]
+                x0 = bounding_box['x'] - bounding_box['width'] / 2#start_column
+                x1 = bounding_box['x'] + bounding_box['width'] / 2#end_column
+                y0 = bounding_box['y'] - bounding_box['height'] / 2#start row
+                y1 = bounding_box['y'] + bounding_box['height'] / 2#end_row
+                class_name = bounding_box['class']
+                croppedArea = img[int(y0):int(y1), int(x0):int(x1)]
+                #confidence_score = bounding_box['confidence']#confidence score of prediction
+
+                if save_img:
+                    if os.path.exists(os.curdir + f"/inference_images/cropBoxes/DetectedAs_{class_name}"
+                        ) is False:
+                        os.mkdir(os.curdir + f"/inference_images/cropBoxes/DetectedAs_{class_name}")
+                    
+                    filename = f"Crop{crop_number}_{original_file}"
+                    save_loc = f'./inference_images/cropBoxes/DetectedAs_{class_name}/' + filename
+                    print(filename, save_loc)
+                    cv2.imwrite(save_loc, croppedArea)
+
+                    print(f'Success! Saved to {save_loc}')
+                    crop_number+=1
+
+                if printJson:
+                    print(f'\n{bounding_box}')
+                
+    else:
+        return print('Please input a valid path to an image or directory (folder)')
+
+
+## load config file for the models
+with open(os.pardir + '/roboflow_config.json') as f:
+    config = json.load(f)
+
+    ROBOFLOW_API_KEY = config["ROBOFLOW_API_KEY"]
+    ROBOFLOW_WORKSPACE_ID = config["ROBOFLOW_WORKSPACE_ID"]
+    ROBOFLOW_MODEL_ID = config["ROBOFLOW_MODEL_ID"]
+    ROBOFLOW_VERSION_NUMBER = config["ROBOFLOW_VERSION_NUMBER"]
+    ROBOFLOW_SIZE = config["ROBOFLOW_SIZE"]
+
+    f.close()
+
+## obtaining your API key: https://docs.roboflow.com/rest-api#obtaining-your-api-key
+## create Roboflow object: https://docs.roboflow.com/python
+rf = Roboflow(api_key=ROBOFLOW_API_KEY)
+workspace = rf.workspace(ROBOFLOW_WORKSPACE_ID)
+project = workspace.project(ROBOFLOW_MODEL_ID)
+version = project.version(ROBOFLOW_VERSION_NUMBER)
+model = version.model
+
+## creating a directory to add images we wish to infer
+if os.path.exists(os.curdir + '/inference_images') is False:
+    os.mkdir(os.curdir + '/inference_images')
+
+## creating directory to place Roboflow prediction images
+if os.path.exists(os.curdir + '/inference_images/inferred') is False:
+    os.mkdir(os.curdir + '/inference_images/inferred')
+
+## creating directory to place prediction images with filled bounding boxes
+if os.path.exists(os.curdir + '/inference_images/cropBoxes') is False:
+    os.mkdir(os.curdir + '/inference_images/cropBoxes')
+
+for raw_data_ext in ['.jpg', '.jpeg', 'png']:
+    globbed_files = glob.glob(os.curdir + '/*' + raw_data_ext)
+    for img_file in globbed_files:
+        shutil.move(img_file, os.curdir + '/inference_images')
+
+cropBoxes(model, './inference_images', confidence = 40, overlap = 30)

--- a/images/fillBoxes.py
+++ b/images/fillBoxes.py
@@ -1,0 +1,138 @@
+import os, glob, shutil
+from roboflow import Roboflow
+import json
+import cv2
+
+
+def fillBoxes(model, img_path, printJson = True, save_img = True, confidence = 40, overlap = 30):
+    """
+    This function fills the bounding boxes on images passed for prediction to your Roboflow model endpoint and also saves the "unfilled" prediction image\n
+    :param model: Roboflow model object for the first inference pass\n
+    :param img_path: string, path to the image for inference\n
+    :param printJson: bool, default: True - prints the JSON values of the predictions from the second inference pass\n
+    :param save_img: bool, default: True - saves the prediction image [crop] from the second inference pass\n
+    :param confidence: int, default: 40 - minimum confidence level (%) to return predictions\n
+    :param overlap: int, default: 30 - maximum prediction overlap (% bounding boxes can overlap prior to being considered the same box/detection)
+    """
+    ## for a directory (folder) of images
+    if os.path.isdir(img_path):
+        raw_data_location = img_path
+        for raw_data_ext in ['.jpg', '.jpeg', 'png']:
+            globbed_files = glob.glob(raw_data_location + '/*' + raw_data_ext)
+            for img_file in globbed_files:
+                img = cv2.imread(img_file)
+                ## perform inference on the selected image
+                predictions = model.predict(img_file, confidence=confidence,
+                    overlap=overlap)
+                #predictions_json = predictions.json()
+                original_file = os.path.basename(img_file).split('/')[-1]
+                predictions.save(os.curdir + f"/inference_images/inferred/{original_file}")
+                ## drawing bounding boxes with the Pillow library
+                ## https://docs.roboflow.com/inference/hosted-api#response-object-format
+                for bounding_box in predictions:
+                    # defining bounding box area and saving class name and confidence scores
+                    x0 = bounding_box['x'] - bounding_box['width'] / 2#start_column
+                    x1 = bounding_box['x'] + bounding_box['width'] / 2#end_column
+                    y0 = bounding_box['y'] - bounding_box['height'] / 2#start row
+                    y1 = bounding_box['y'] + bounding_box['height'] / 2#end_row
+                    # class_name = bounding_box['class']
+                    # confidence_score = bounding_box['confidence']#confidence score of prediction
+                    start_point = (int(x0), int(y0))# bounding box start point (pt1)
+                    end_point = (int(x1), int(y1))# bounding box end point (pt2)
+
+                    ## draw/place filled bounding boxes on image
+                    cv2.rectangle(img, start_point, end_point, color=(0,0,0), thickness=-1)
+
+                    if save_img:
+                        if os.path.exists(os.curdir + f"/inference_images/fillBoxes"
+                            ) is False:
+                            os.mkdir(os.curdir + f"/inference_images/fillBoxes")
+                        
+                        filename = original_file
+                        save_loc = f'./inference_images/fillBoxes/' + filename
+                        cv2.imwrite(save_loc, img)
+
+                        print(f'Success! Saved to {save_loc}')
+
+                    if printJson:
+                        print(f'\n{bounding_box}')
+                        
+    ## runs if there is only 1 image file in the ./inference_images directory
+    elif os.path.isfile(img_path):
+        img = cv2.imread(img_path)
+        ## perform inference on the selected image
+        predictions = model.predict(img_path, confidence=confidence,
+            overlap=overlap)
+        #predictions_json = predictions.json()
+        original_file = os.path.basename(img_path).split('/')[-1]
+        predictions.save(os.curdir + f"/inference_images/inferred/{original_file}")
+        ## drawing bounding boxes with the Pillow library
+        ## https://docs.roboflow.com/inference/hosted-api#response-object-format
+        for bounding_box in predictions:
+            ## defining bounding box area and saving class name and confidence scores
+            x0 = bounding_box['x'] - bounding_box['width'] / 2#start_column
+            x1 = bounding_box['x'] + bounding_box['width'] / 2#end_column
+            y0 = bounding_box['y'] - bounding_box['height'] / 2#start row
+            y1 = bounding_box['y'] + bounding_box['height'] / 2#end_row
+            start_point = (int(x0), int(y0))# bounding box start point (pt1)
+            end_point = (int(x1), int(y1))# bounding box end point (pt2)
+
+            ## draw/place bounding boxes on image
+            cv2.rectangle(img, start_point, end_point, color=(0,0,0), thickness=-1)
+        
+            if save_img:
+                if os.path.exists(os.curdir + f"/inference_images/fillBoxes"
+                    ) is False:
+                    os.mkdir(os.curdir + f"/inference_images/fillBoxes")
+                
+                filename = original_file
+                save_loc = f'./inference_images/fillBoxes/' + filename
+                cv2.imwrite(save_loc, img)
+
+                print(f'Success! Saved to {save_loc}')
+
+            if printJson:
+                print(f'\n{bounding_box}')
+                
+    else:
+        return print('Please input a valid path to an image or directory (folder)')
+
+
+## load config file for the models
+with open(os.pardir + '/roboflow_config.json') as f:
+    config = json.load(f)
+
+    ROBOFLOW_API_KEY = config["ROBOFLOW_API_KEY"]
+    ROBOFLOW_WORKSPACE_ID = config["ROBOFLOW_WORKSPACE_ID"]
+    ROBOFLOW_MODEL_ID = config["ROBOFLOW_MODEL_ID"]
+    ROBOFLOW_VERSION_NUMBER = config["ROBOFLOW_VERSION_NUMBER"]
+    ROBOFLOW_SIZE = config["ROBOFLOW_SIZE"]
+
+    f.close()
+
+## obtaining your API key: https://docs.roboflow.com/rest-api#obtaining-your-api-key
+## create Roboflow object: https://docs.roboflow.com/python
+rf = Roboflow(api_key=ROBOFLOW_API_KEY)
+workspace = rf.workspace(ROBOFLOW_WORKSPACE_ID)
+project = workspace.project(ROBOFLOW_MODEL_ID)
+version = project.version(ROBOFLOW_VERSION_NUMBER)
+model = version.model
+
+## creating a directory to add images we wish to infer
+if os.path.exists(os.curdir + '/inference_images') is False:
+    os.mkdir(os.curdir + '/inference_images')
+
+## creating directory to place Roboflow prediction images
+if os.path.exists(os.curdir + '/inference_images/inferred') is False:
+    os.mkdir(os.curdir + '/inference_images/inferred')
+
+## creating directory to place prediction images with filled bounding boxes
+if os.path.exists(os.curdir + '/inference_images/fillBoxes') is False:
+    os.mkdir(os.curdir + '/inference_images/fillBoxes')
+
+for raw_data_ext in ['.jpg', '.jpeg', 'png']:
+    globbed_files = glob.glob(os.curdir + '/*' + raw_data_ext)
+    for img_file in globbed_files:
+        shutil.move(img_file, os.curdir + '/inference_images')
+
+fillBoxes(model, './inference_images', confidence = 40, overlap = 30)


### PR DESCRIPTION
# Description

Added inference image customization standalone scripts to complement `predictionUtils.py` (the object-oriented version that contains capabilities for all of the scripts)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested with my own models on my computer 3x each for each script

## Any specific deployment considerations

Updated ReadMe with better instructions for finding the scripts, and example use code

## Docs

-   [x] Docs updated? What were the changes: Updated ReadMe
